### PR TITLE
Task cleanup

### DIFF
--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -189,13 +189,11 @@ export default {
       const res = await axios.post("/api/task", {
         //If we want to autogenerate a value, change one of the values here
         vals: [
-          taskId, //Ex: instead of taskId here, we could have a random number generated.
           groupId,
           description,
           deadline,
           taskName,
-          userId,
-          status
+          userId 
         ]
       });
       console.log(res);

--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -39,7 +39,7 @@ module.exports = {
     },
     createNewComment: (req, res) => {
         console.log(req.isAuthenticated());
-        if(true || req.isAuthenticated()){
+        if(req.isAuthenticated()){
           const commentData = req.body.vals;
           console.log(commentData);
             db.Comment.insertOne(commentData, result => {

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -10,13 +10,14 @@ module.exports = {
     createNewTask: (req, res) => {
         console.log(req.isAuthenticated());
         if(req.isAuthenticated()){
-          const userData = req.body.vals;
-            db.Task.insertOne(userData, result => {
+          const taskData = req.body.vals;
+          console.log(taskData);
+            db.Task.insertOne(taskData, result => {
               res.status(200).json({ id: result.insertId });
             });
         }
         else {
-          res.status(400);
+          res.status(400).end();
         }
       },
     updateTaskById: (req, res) => {

--- a/models/task.js
+++ b/models/task.js
@@ -19,7 +19,7 @@ const Task = {
   },
     insertOne: (vals, cb) => {
         const queryString =
-        "INSERT INTO Tasks(taskId, groupId, description, deadline, taskName, userId, creationDate, status) VALUES(?,?,?,?,?,?,?,?)"
+        "INSERT INTO Tasks(groupId, description, deadline, taskName, userId) VALUES(?,?,?,?,?)"
         connection.execute(queryString, vals, (err, result) => {
             if (err) throw err;
             cb(result);


### PR DESCRIPTION
got rid of taskId, creationDate, status from the creation of a task because those should be auto generated by the database anyway.